### PR TITLE
chore(GEM-19): model responses with entire chat

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -17,9 +17,11 @@ import type {
 import type * as auth from "../auth.js";
 import type * as http from "../http.js";
 import type * as messages from "../messages.js";
+import type * as messagesHelpers from "../messagesHelpers.js";
 import type * as model from "../model.js";
 import type * as settings from "../settings.js";
 import type * as settingsHelpers from "../settingsHelpers.js";
+import type * as threadHelpers from "../threadHelpers.js";
 import type * as threads from "../threads.js";
 import type * as userHelpers from "../userHelpers.js";
 import type * as users from "../users.js";
@@ -36,9 +38,11 @@ declare const fullApi: ApiFromModules<{
   auth: typeof auth;
   http: typeof http;
   messages: typeof messages;
+  messagesHelpers: typeof messagesHelpers;
   model: typeof model;
   settings: typeof settings;
   settingsHelpers: typeof settingsHelpers;
+  threadHelpers: typeof threadHelpers;
   threads: typeof threads;
   userHelpers: typeof userHelpers;
   users: typeof users;

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -3,11 +3,17 @@ import { v } from "convex/values";
 import { internalAction, internalMutation, mutation, query, action, internalQuery } from "./_generated/server";
 import { auth } from "./auth";
 import { getAll, getManyFrom } from "convex-helpers/server/relationships";
-import { model } from "./model";
-import { Id } from "./_generated/dataModel";
+import { chatResponse, singleMessageChat, singleOutputResponse } from "./model";
+import { Doc, Id } from "./_generated/dataModel";
 import { internal } from "./_generated/api";
 import { DatabaseReader } from "./_generated/server";
+import { getUserSettings } from "./settingsHelpers";
+import { getEntireChat, summarizeThread } from "./threadHelpers";
+import { settingsSchema } from "./schema";
+import { literals } from "convex-helpers/validators";
+import { runModelResponses } from "./messagesHelpers";
 
+// viewing the message in thread
 export const viewer = query({
   args: { threadId: v.id("threads") },
   handler: async (ctx, args_0) => {
@@ -16,9 +22,18 @@ export const viewer = query({
   },
 });
 
+export const threadMessages = internalQuery({
+  args: { threadId: v.id("threads") },
+  handler: async (ctx, args_0) => {
+    return await getEntireChat(ctx, args_0.threadId);
+  },
+});
+
+// creating the messages, either user or system or assistant
 export const createMessage = mutation({
   args: { content: v.string(), threadId: v.id("threads") },
   handler: async (ctx, args) => {
+    // adding the new message written by the user to the db
     const user = await auth.getUserId(ctx);
     const newMessage = await ctx.db.insert("messages", {
       threadId: args.threadId,
@@ -26,72 +41,38 @@ export const createMessage = mutation({
       state: "generating",
       author: { role: "user", userId: user! },
     });
+    // getting the user settings
+    const { settings } = await getUserSettings(ctx);
+    await summarizeThread(ctx, args.threadId, settings!);
 
-    const firstMessage = await ctx.db
-      .query("messages")
-      .withIndex("threadId", (q) => q.eq("threadId", args.threadId))
-      .collect();
-
-    if (firstMessage.length === 1) {
-      await ctx.scheduler.runAfter(0, internal.messages.summarize, {
-        threadId: args.threadId,
-        firstMessage: firstMessage[0].message,
-      });
-    }
-
-    await ctx.scheduler.runAfter(0, internal.messages.runModelResponse, {
-      messageId: newMessage,
-      threadId: args.threadId,
-      content: args.content,
-    });
+    await runModelResponses(ctx,newMessage,args.content,args.threadId, settings!)
   },
 });
 
-export const runModelResponse = internalMutation({
-  args: {
-    messageId: v.id("messages"),
-    threadId: v.id("threads"),
-    content: v.string(), // message to respond to
-  },
-  handler: async (ctx, args_0) => {
-    const newMessageUpdate = await ctx.db.insert("messages", {
-      threadId: args_0.threadId,
-      message: "...",
-      author: {
-        role: "assistant",
-      },
-      state: "generating",
-    });
-
-    await ctx.scheduler.runAfter(0, internal.messages.maintainStream, {
-      messageId: newMessageUpdate,
-      content: args_0.content,
-    });
-  },
-});
-
-export const maintainStream = internalAction({
-  args: { content: v.string(), messageId: v.id("messages") },
-  handler: async (ctx, args) => {
-    let chunkedText = "";
-    const result = await model.generateContentStream(args.content);
+export const singleMessageResponse = internalAction({
+  args:{messageId:v.id("messages"), content:v.string(), threadId:v.id("threads"), settings:v.object(settingsSchema)},
+  handler:async(ctx, args_0)=>{
+    console.log("single chat response")
+    const result = await singleMessageChat(args_0.content, args_0.settings);
     for await (const chunk of result.stream) {
       const chunkText = chunk.text();
-      chunkedText += chunkText;
-      await ctx.scheduler.runAfter(0, internal.messages.setUpMessage, {
-        messageId: args.messageId,
+      // chunkedText += chunkText;
+      await ctx.runMutation( internal.messages.setUpMessage, {
+        messageId: args_0.messageId,
         messageChunk: chunkText,
+        state:"generating"
       });
     }
-    await ctx.scheduler.runAfter(0, internal.messages.finishJob, {
-      messageId: args.messageId,
-      completeMessage: chunkedText, // Send the complete message
+    await ctx.runMutation(internal.messages.finishJob, {
+      messageId: args_0.messageId,
+      completeMessage: "", // Send the complete message
+      state:"success"
     });
   },
-});
+})
 
 export const setUpMessage = internalMutation({
-  args: { messageId: v.id("messages"), messageChunk: v.string() },
+  args: { messageId: v.id("messages"), messageChunk: v.string() ,state:literals("success", "generating", "failed")},
   handler: async (ctx, args_0) => {
     const existingMessage = await ctx.db.get(args_0.messageId);
     const updatedMessage = existingMessage!.message + args_0.messageChunk;
@@ -102,7 +83,7 @@ export const setUpMessage = internalMutation({
 });
 
 export const finishJob = internalMutation({
-  args: { messageId: v.id("messages"), completeMessage: v.string() },
+  args: { messageId: v.id("messages"), completeMessage: v.string(), state:literals("success", "generating", "failed")},
   handler: async (ctx, args_0) => {
     await ctx.db.patch(args_0.messageId, {
       state: "success",
@@ -111,22 +92,58 @@ export const finishJob = internalMutation({
   },
 });
 
+// entire chat response
+export const runEntireChat = internalAction({
+  args: { settings: v.object(settingsSchema), threadId: v.id("threads"), messageId: v.id("messages") },
+  handler: async (ctx, args_0) => {
+    const messages = await ctx.runQuery(internal.messages.threadMessages, { threadId: args_0.threadId });
+    const result = await chatResponse(messages, args_0.settings);
+    for await (const chunk of result.stream) {
+      await ctx.runMutation(internal.messages.patchStreamMessage, {
+        messageId: args_0.messageId,
+        chunk: chunk.text(),
+        state: "generating",
+      });
+    }
+    await ctx.runMutation(internal.messages.patchStreamMessage, {
+      messageId: args_0.messageId,
+      chunk: ".",
+      state: "success",
+    });
+  },
+});
+
+// patch existing message
+export const patchStreamMessage = internalMutation({
+  args: { messageId: v.id("messages"), chunk: v.string(), state: literals("success", "generating", "failed") },
+  handler: async (ctx, args_0) => {
+    const message = await ctx.db.get(args_0.messageId);
+    const updatedMessage = message?.message + args_0.chunk;
+    await ctx.db.patch(args_0.messageId, {
+      message: updatedMessage,
+      state: args_0.state,
+    });
+  },
+});
+
+/** Summarize functions */
 export const summarize = internalAction({
-  args: { threadId: v.id("threads"), firstMessage: v.string() },
+  args: { threadId: v.id("threads"), firstMessage: v.string(), settings:v.any() },
   handler: async (ctx, args_0) => {
     const prompt = `write a proper summary that describes the following message ${args_0.firstMessage}, make it small, straight to the point, no longer than 30 characters, don't type anything else other than chat title summary.`;
 
     await ctx.scheduler.runAfter(5000, internal.messages.actionToSummarize, {
       prompt: prompt,
       threadId: args_0.threadId,
+      settings: args_0.settings as Doc<"settings">,
     });
   },
 });
 
 export const actionToSummarize = internalAction({
-  args: { prompt: v.string(), threadId: v.id("threads") },
+  args: { prompt: v.string(), threadId: v.id("threads"), settings: v.any() },
   handler: async (ctx, args_0) => {
-    const request = await model.generateContent(args_0.prompt);
+    const request = await singleOutputResponse(args_0.prompt, args_0.settings as Doc<"settings">);
     const response = request.response.text();
     await ctx.scheduler.runAfter(0, internal.messages.updateSummery, {
       output: response,

--- a/convex/messagesHelpers.ts
+++ b/convex/messagesHelpers.ts
@@ -1,0 +1,31 @@
+import { internal } from "./_generated/api";
+import { Doc, Id } from "./_generated/dataModel";
+import { MutationCtx } from "./_generated/server";
+import { singleMessageChat } from "./model";
+
+export const runModelResponses = async(ctx:MutationCtx, messageId:Id<"messages">,content:string, threadId:Id<"threads">,settings:Doc<"settings">) =>{
+  const newMessageUpdate = await ctx.db.insert("messages", {
+    threadId: threadId,
+    message: "...",
+    author: {
+      role: "assistant",
+    },
+    state: "generating",
+  });
+
+  if (settings.responseType === "single-message") {
+    await ctx.scheduler.runAfter(0, internal.messages.singleMessageResponse,{
+      messageId:messageId,
+      content:content,
+      threadId:threadId,
+      settings:settings
+    })
+  } else {
+    // run for entire chat response
+    await ctx.scheduler.runAfter(0, internal.messages.runEntireChat, {
+      settings: settings,
+      threadId: threadId,
+      messageId: newMessageUpdate, // to patch by the model
+    });
+  }
+}

--- a/convex/messagesHelpers.ts
+++ b/convex/messagesHelpers.ts
@@ -15,7 +15,7 @@ export const runModelResponses = async(ctx:MutationCtx, messageId:Id<"messages">
 
   if (settings.responseType === "single-message") {
     await ctx.scheduler.runAfter(0, internal.messages.singleMessageResponse,{
-      messageId:messageId,
+      messageId:newMessageUpdate,
       content:content,
       threadId:threadId,
       settings:settings

--- a/convex/model.ts
+++ b/convex/model.ts
@@ -4,7 +4,6 @@ import { QueryCtx } from "./_generated/server";
 
 const apiKey = process.env.GEMINI_API_KEY;
 const genAI = new GoogleGenerativeAI(apiKey as string);
-
 export const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash"});
 
 export const generationConfig = {
@@ -18,14 +17,14 @@ export const generationConfig = {
 // export const model = genAI.getGenerativeModel({ model:  });
 // return a response of a stream for a single message
 export const singleMessageChat = async (message: string, settings: Partial<Doc<"settings">>) => {
-  model.model = settings.model as string
+  // model.model = settings.model as string
   const result = await model.generateContentStream(message);
   return result;
 };
 
 export const singleOutputResponse = async (message: string, settings: Partial<Doc<"settings">>) => {
   // const model = genAI.getGenerativeModel({ model: settings.model as string });
-  model.model = settings.model as string
+  // model.model = settings.model as string
   const result = await model.generateContent(message);
   return result;
 };
@@ -33,7 +32,7 @@ export const singleOutputResponse = async (message: string, settings: Partial<Do
 // all chat
 export const chatResponse = async (messages: Doc<"messages">[], settings: Partial<Doc<"settings">>) => {
   // const model = genAI.getGenerativeModel({ model: settings.model as string});
-  model.model = settings.model as string
+  // model.model = settings.model as string
   const history:Content[] = messages.map((singleMessage, index) => {
     return {
       role: singleMessage.author.role === "assistant" ? "model" : "user",

--- a/convex/model.ts
+++ b/convex/model.ts
@@ -1,6 +1,52 @@
-import { GoogleGenerativeAI } from "@google/generative-ai";
+import { Content, GoogleGenerativeAI, ModelParams } from "@google/generative-ai";
+import { Doc } from "./_generated/dataModel";
+import { QueryCtx } from "./_generated/server";
 
-// Access your API key as an environment variable (see "Set up your API key" above)
-const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY as string);
+const apiKey = process.env.GEMINI_API_KEY;
+const genAI = new GoogleGenerativeAI(apiKey as string);
 
 export const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash"});
+
+export const generationConfig = {
+  temperature: 1,
+  topP: 0.95,
+  topK: 64,
+  maxOutputTokens: 8192,
+  responseMimeType: "text/plain",
+};
+
+// export const model = genAI.getGenerativeModel({ model:  });
+// return a response of a stream for a single message
+export const singleMessageChat = async (message: string, settings: Partial<Doc<"settings">>) => {
+  model.model = settings.model as string
+  const result = await model.generateContentStream(message);
+  return result;
+};
+
+export const singleOutputResponse = async (message: string, settings: Partial<Doc<"settings">>) => {
+  // const model = genAI.getGenerativeModel({ model: settings.model as string });
+  model.model = settings.model as string
+  const result = await model.generateContent(message);
+  return result;
+};
+
+// all chat
+export const chatResponse = async (messages: Doc<"messages">[], settings: Partial<Doc<"settings">>) => {
+  // const model = genAI.getGenerativeModel({ model: settings.model as string});
+  model.model = settings.model as string
+  const history:Content[] = messages.map((singleMessage, index) => {
+    return {
+      role: singleMessage.author.role === "assistant" ? "model" : "user",
+      parts: [{
+        text: singleMessage.message,
+      }],
+    };
+  });
+
+  const chatSession = model.startChat({
+    generationConfig,
+    history
+  })
+  const result = await chatSession.sendMessageStream(messages[messages.length-1].message);
+  return result
+};

--- a/convex/model.ts
+++ b/convex/model.ts
@@ -1,12 +1,11 @@
-import { Content, GoogleGenerativeAI, ModelParams } from "@google/generative-ai";
+import { Content, GenerationConfig, GoogleGenerativeAI, ModelParams } from "@google/generative-ai";
 import { Doc } from "./_generated/dataModel";
 import { QueryCtx } from "./_generated/server";
 
 const apiKey = process.env.GEMINI_API_KEY;
 const genAI = new GoogleGenerativeAI(apiKey as string);
-export const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash"});
-
-export const generationConfig = {
+// export const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash"});
+export const generationConfig:GenerationConfig = {
   temperature: 1,
   topP: 0.95,
   topK: 64,
@@ -14,17 +13,15 @@ export const generationConfig = {
   responseMimeType: "text/plain",
 };
 
-// export const model = genAI.getGenerativeModel({ model:  });
 // return a response of a stream for a single message
 export const singleMessageChat = async (message: string, settings: Partial<Doc<"settings">>) => {
-  // model.model = settings.model as string
+  const model = genAI.getGenerativeModel({ model: settings.model as string})
   const result = await model.generateContentStream(message);
   return result;
 };
 
 export const singleOutputResponse = async (message: string, settings: Partial<Doc<"settings">>) => {
-  // const model = genAI.getGenerativeModel({ model: settings.model as string });
-  // model.model = settings.model as string
+  const model = genAI.getGenerativeModel({ model: settings.model as string})
   const result = await model.generateContent(message);
   return result;
 };
@@ -32,7 +29,7 @@ export const singleOutputResponse = async (message: string, settings: Partial<Do
 // all chat
 export const chatResponse = async (messages: Doc<"messages">[], settings: Partial<Doc<"settings">>) => {
   // const model = genAI.getGenerativeModel({ model: settings.model as string});
-  // model.model = settings.model as string
+  const model = genAI.getGenerativeModel({ model: settings.model as string})
   const history:Content[] = messages.map((singleMessage, index) => {
     return {
       role: singleMessage.author.role === "assistant" ? "model" : "user",

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -5,60 +5,18 @@ import { literals } from "convex-helpers/validators";
 
 export const settingsSchema = {
   userId: v.id("users"),
-  responseType: v.union(v.literal("chat"), v.literal("single-message")),
-  theme: v.union(v.literal("dark"), v.literal("light")),
+  responseType: literals("chat","single-message"),
+  theme:literals("dark","light"),
   keepChat: v.number(), // How long to keep the chats for // max of 30 days
   attachments:v.object({
       audio: v.boolean(),
       images: v.boolean(),
     }),
-  model: v.union(
-    v.literal("gemini-1.5-pro"),
-    v.literal("gemini-1.5-flash"),
-    v.literal("gemini-1.0-pro"),
-    v.literal("text-embedding-004"),
-    v.literal("aqa")
-  ),
-  languages: v.union(
-    v.literal("ar"),
-    v.literal("bn"),
-    v.literal("bg"),
-    v.literal("zh"),
-    v.literal("hr"),
-    v.literal("cs"),
-    v.literal("da"),
-    v.literal("nl"),
-    v.literal("en"),
-    v.literal("et"),
-    v.literal("fi"),
-    v.literal("fr"),
-    v.literal("de"),
-    v.literal("el"),
-    v.literal("iw"),
-    v.literal("hi"),
-    v.literal("hu"),
-    v.literal("id"),
-    v.literal("it"),
-    v.literal("ja"),
-    v.literal("ko"),
-    v.literal("lv"),
-    v.literal("lt"),
-    v.literal("no"),
-    v.literal("pl"),
-    v.literal("pt"),
-    v.literal("ro"),
-    v.literal("ru"),
-    v.literal("sr"),
-    v.literal("sk"),
-    v.literal("sl"),
-    v.literal("es"),
-    v.literal("sw"),
-    v.literal("sv"),
-    v.literal("th"),
-    v.literal("tr"),
-    v.literal("uk"),
-    v.literal("vi")
-  ),
+  model: literals("gemini-1.5-pro","gemini-1.5-flash","gemini-1.0-pro","text-embedding-004","aqa"),
+  languages: literals("ar","bn","bg","zh","hr","cs","da","nl",
+    "en","et","fi","fr","de","el","iw","hi","hu","id","it","ja",
+    "ko","lv","lt","no","pl","pt","ro","ru","sr","sk","sl","es",
+    "sw","sv","th","tr","uk","vi")
 }
 
 const schema = defineSchema({

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -12,7 +12,7 @@ export const settingsSchema = {
       audio: v.boolean(),
       images: v.boolean(),
     }),
-  model: literals("gemini-1.5-pro","gemini-1.5-flash","gemini-1.0-pro","text-embedding-004","aqa"),
+  model: literals("gemini-1.0-pro","gemini-1.0-pro-latest","gemini-1.0-pro-001","gemini-1.5-flash","gemini-1.5-flash-latest","gemini-1.5-pro-latest","gemini-1.5-pro"),
   languages: literals("ar","bn","bg","zh","hr","cs","da","nl",
     "en","et","fi","fr","de","el","iw","hi","hu","id","it","ja",
     "ko","lv","lt","no","pl","pt","ro","ru","sr","sk","sl","es",

--- a/convex/settings.ts
+++ b/convex/settings.ts
@@ -26,7 +26,7 @@ export const createUserSettings = mutation({
         theme:"light",
         keepChat:(Date.now() + 604800), // 1 week
         languages:"en",
-        model:"gemini-1.0-pro",
+        model:"gemini-1.0-pro-latest",
         attachments:{
           audio:false,
           images:false

--- a/convex/settingsHelpers.ts
+++ b/convex/settingsHelpers.ts
@@ -6,7 +6,7 @@ export const getUserSettings = async(
   ctx: QueryCtx,
 )=>{
   const userId = await auth.getUserId(ctx);
-  const settings = ctx.db.query('settings')
+  const settings = await ctx.db.query('settings')
     .withIndex('userId', q => q.eq('userId', userId!)).unique()
-  return {settings,userId}
+  return {settings , userId}
 }

--- a/convex/threadHelpers.ts
+++ b/convex/threadHelpers.ts
@@ -1,0 +1,23 @@
+import { internal } from "./_generated/api";
+import { Doc, Id } from "./_generated/dataModel";
+import { MutationCtx, QueryCtx } from "./_generated/server";
+
+// summarize thread through first messages
+export const summarizeThread = async (ctx: MutationCtx, threadId: Id<"threads">, settings:Doc<"settings">) => {
+  const firstMessage = await ctx.db
+    .query("messages")
+    .withIndex("threadId", (q) => q.eq("threadId", threadId))
+    .collect();
+  if (firstMessage.length === 1) {
+    await ctx.scheduler.runAfter(0, internal.messages.summarize, {
+      threadId: threadId,
+      firstMessage: firstMessage[0].message,
+      settings:settings
+    });
+  }
+};
+
+export const getEntireChat = async(ctx:QueryCtx,id:Id<"threads">) =>{
+  const allMessages = await ctx.db.query("messages").withIndex("threadId",q=> q.eq("threadId",id)).collect();
+  return allMessages
+}

--- a/src/app/settings/account/AccountForm.tsx
+++ b/src/app/settings/account/AccountForm.tsx
@@ -35,7 +35,7 @@ export function AccountForm() {
   const form = useForm<AccountFormValues>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      model:settings?.model ?? "gemini-1.0-pro",
+      // model:settings?.model ?? "gemini-1.0-pro",
       languages: settings?.languages ?? "en",
       theme: settings?.theme ?? "light",
       attachments:{
@@ -43,11 +43,12 @@ export function AccountForm() {
         images:settings?.attachments.images ?? false,
       },
       keepChat: settings?.keepChat ?? (Date.now()+ 604800), // 1 week 
-      responseType: settings?.responseType ?? "single-message",
+      // responseType: settings?.responseType ?? "single-message",
     },
   });
 
   function onSubmit(data: AccountFormValues) {
+    // console.log(data)
     updateSettings({settingsId:settings?._id as Id<"settings">, body: data as Partial<Doc<"settings">>})
   }
 
@@ -67,7 +68,7 @@ export function AccountForm() {
             <FormItem className="flex flex-col">
               <FormLabel>Response Type</FormLabel>
               <FormControl>
-                <Select onValueChange={(value:Response) => field.onChange(form.setValue("responseType", value))}>
+                <Select onValueChange={(value:Response) => form.setValue("responseType",value)}>
                   <SelectTrigger className="w-[180px]">
                     <SelectValue placeholder="response type" />
                   </SelectTrigger>
@@ -161,7 +162,7 @@ export function AccountForm() {
             <FormItem className="flex flex-col">
               <FormLabel>Model</FormLabel>
               <FormControl>
-                <Select onValueChange={(value:Model) => field.onChange(form.setValue("model", value))}>
+                <Select onValueChange={(value:Model) => form.setValue('model',value)}>
                   <SelectTrigger className="w-[180px]">
                     <SelectValue placeholder="model type" />
                   </SelectTrigger>

--- a/src/app/settings/account/constants.ts
+++ b/src/app/settings/account/constants.ts
@@ -56,8 +56,8 @@ export const accountFormSchema = (settings: Doc<"settings">) => {
       images: z.boolean().default(settings?.attachments.images ?? false),
     }),
     model: z
-      .enum(["gemini-1.5-pro", "gemini-1.5-flash", "gemini-1.0-pro", "text-embedding-004", "aqa"])
-      .default(settings?.model ?? "gemini-1.0-pro"),
+      .enum(["gemini-1.0-pro","gemini-1.0-pro-latest","gemini-1.0-pro-001","gemini-1.5-flash","gemini-1.5-flash-latest","gemini-1.5-pro-latest","gemini-1.5-pro"])
+      .default(settings?.model ?? "gemini-1.0-pro-latest"),
     languages: z.enum(languagesSet).default(settings?.languages ?? "en"),
     theme: z.enum(["light", "dark"]).default(settings?.theme ?? "light"),
   });
@@ -66,5 +66,5 @@ export const accountFormSchema = (settings: Doc<"settings">) => {
 export const responses: readonly string[] = ["chat", "single-message"];
 export type Response = "chat"| "single-message"
 
-export const models:readonly string[] = ["gemini-1.5-pro", "gemini-1.5-flash", "gemini-1.0-pro", "text-embedding-004", "aqa"]
-export type Model = "gemini-1.5-pro"| "gemini-1.5-flash"| "gemini-1.0-pro"| "text-embedding-004"| "aqa"
+export const models:readonly string[] = ["gemini-1.0-pro","gemini-1.0-pro-latest","gemini-1.0-pro-001","gemini-1.5-flash","gemini-1.5-flash-latest","gemini-1.5-pro-latest","gemini-1.5-pro"]
+export type Model = "gemini-1.0-pro"|"gemini-1.0-pro-latest"|"gemini-1.0-pro-001"|"gemini-1.5-flash"|"gemini-1.5-flash-latest"|"gemini-1.5-pro-latest"|"gemini-1.5-pro"


### PR DESCRIPTION
# Demo:
- responses can be based on user settings, (entire chat or just the previous message)
![image](https://github.com/user-attachments/assets/84beb3af-76bc-44f1-9237-f471dbd6cc61)
- model names are updated based on `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash?key=${your key}`, since not all of them are stable.

# TL;DR
entire chat response
# Additional information 
none